### PR TITLE
Update gtkwave.rb

### DIFF
--- a/gtkwave.rb
+++ b/gtkwave.rb
@@ -13,6 +13,7 @@ class Gtkwave < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "gtk+3"
+  depends_on "gtk4"
 
   def install
     ENV["DESTDIR"] = "/"


### PR DESCRIPTION
GTKWave requires GTK4 on macOS, meson won't build without it as a dependency.